### PR TITLE
Add simple board movement

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,8 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Board Game Dice Roller</title>
     <style>
-        body { font-family: Arial, sans-serif; max-width: 600px; margin: auto; padding: 20px; }
+        body { font-family: Arial, sans-serif; max-width: 900px; margin: auto; padding: 20px; }
         #log { border: 1px solid #ccc; height: 200px; overflow-y: scroll; padding: 5px; }
+        #board { display: grid; grid-template-columns: repeat(6, 1fr); grid-template-rows: repeat(6, 1fr); gap: 2px; max-width: 90vmin; max-height: 90vmin; margin: 20px auto; }
+        .space { border: 1px solid #999; position: relative; min-height: 40px; }
+        .token { width: 15px; height: 15px; border-radius: 50%; position: absolute; top: 2px; left: 2px; }
+        .p0 { background: red; }
+        .p1 { background: blue; }
+        .p2 { background: green; }
+        .p3 { background: yellow; }
     </style>
 </head>
 <body>
@@ -17,6 +24,7 @@
     </div>
     <div id="game" style="display:none;">
         <button id="rollBtn">Roll Dice</button>
+        <div id="board"></div>
         <div id="log"></div>
     </div>
 

--- a/public/script.js
+++ b/public/script.js
@@ -5,6 +5,10 @@ const nameInput = document.getElementById('name');
 const joinBtn = document.getElementById('joinBtn');
 const rollBtn = document.getElementById('rollBtn');
 const logDiv = document.getElementById('log');
+const boardDiv = document.getElementById('board');
+let boardSize = 20;
+let boardCoords = [];
+let players = [];
 let playerId = null;
 
 joinBtn.onclick = () => {
@@ -21,6 +25,7 @@ socket.on('joined', (id) => {
     playerId = id;
     joinDiv.style.display = 'none';
     gameDiv.style.display = 'block';
+    if (boardCoords.length === 0) buildBoard();
 });
 
 socket.on('message', msg => {
@@ -37,3 +42,43 @@ socket.on('yourTurn', () => {
 socket.on('notYourTurn', () => {
     rollBtn.disabled = true;
 });
+
+socket.on('state', state => {
+    boardSize = state.boardSize;
+    players = state.players;
+    if (boardCoords.length === 0) {
+        buildBoard();
+    }
+    renderTokens();
+});
+
+function buildBoard() {
+    const N = 6; // 6x6 grid => 20 spaces
+    boardCoords = [];
+    boardDiv.innerHTML = '';
+    for (let c = N - 1; c >= 0; c--) boardCoords.push({ row: N - 1, col: c });
+    for (let r = N - 2; r >= 0; r--) boardCoords.push({ row: r, col: 0 });
+    for (let c = 1; c <= N - 1; c++) boardCoords.push({ row: 0, col: c });
+    for (let r = 1; r <= N - 2; r++) boardCoords.push({ row: r, col: N - 1 });
+    boardCoords.forEach((pos, idx) => {
+        const div = document.createElement('div');
+        div.className = 'space';
+        div.dataset.index = idx;
+        div.style.gridRowStart = pos.row + 1;
+        div.style.gridColumnStart = pos.col + 1;
+        boardDiv.appendChild(div);
+    });
+}
+
+function renderTokens() {
+    document.querySelectorAll('.token').forEach(t => t.remove());
+    players.forEach((p, idx) => {
+        const space = boardDiv.querySelector(`.space[data-index="${p.position}"]`);
+        if (space) {
+            const token = document.createElement('div');
+            token.className = `token p${idx}`;
+            token.title = p.name;
+            space.appendChild(token);
+        }
+    });
+}


### PR DESCRIPTION
## Summary
- extend server to track player positions on a 20‑space board
- restrict the game to four players
- allow rolling two dice and move tokens around the board
- broadcast game state for rendering
- create a responsive board UI with player tokens

## Testing
- `npm install`
- `npm start` *(fails without express before install)*

------
https://chatgpt.com/codex/tasks/task_e_6845cbb03ce0832283015841d157ef93