### PR TITLE
Expand board to monopoly style

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,15 +5,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Board Game Dice Roller</title>
     <style>
-        body { font-family: Arial, sans-serif; max-width: 900px; margin: auto; padding: 20px; }
-        #log { border: 1px solid #ccc; height: 200px; overflow-y: scroll; padding: 5px; }
-        #board { display: grid; grid-template-columns: repeat(6, 1fr); grid-template-rows: repeat(6, 1fr); gap: 2px; max-width: 90vmin; max-height: 90vmin; margin: 20px auto; }
-        .space { border: 1px solid #999; position: relative; min-height: 40px; }
-        .token { width: 15px; height: 15px; border-radius: 50%; position: absolute; top: 2px; left: 2px; }
+        body { font-family: Arial, sans-serif; margin: 0; padding: 20px; }
+        #layout { display: flex; gap: 20px; }
+        #controls, #stats { width: 150px; }
+        #boardWrapper { flex: 1; display: flex; justify-content: center; }
+        #board { position: relative; display: grid; grid-template-columns: repeat(11, 1fr); grid-template-rows: repeat(11, 1fr); max-width: 80vmin; max-height: 80vmin; }
+        #log { grid-column: 2 / 11; grid-row: 2 / 11; border: 1px solid #ccc; overflow-y: scroll; background: #fff; padding: 5px; }
+        .space { border: 1px solid #999; position: relative; font-size: 10px; display: flex; flex-direction: column; align-items: center; justify-content: flex-start; }
+        .space .tokens { display: flex; gap: 2px; flex-wrap: wrap; margin-top: auto; padding-bottom: 2px; }
+        .token { width: 14px; height: 14px; border-radius: 50%; }
         .p0 { background: red; }
         .p1 { background: blue; }
         .p2 { background: green; }
         .p3 { background: yellow; }
+        .property { border-top: 10px solid; }
     </style>
 </head>
 <body>
@@ -23,9 +28,17 @@
         <button id="joinBtn">Join Game</button>
     </div>
     <div id="game" style="display:none;">
-        <button id="rollBtn">Roll Dice</button>
-        <div id="board"></div>
-        <div id="log"></div>
+        <div id="layout">
+            <div id="controls">
+                <button id="rollBtn">Roll Dice</button>
+            </div>
+            <div id="boardWrapper">
+                <div id="board">
+                    <div id="log"></div>
+                </div>
+            </div>
+            <div id="stats"></div>
+        </div>
     </div>
 
     <script src="/socket.io/socket.io.js"></script>

--- a/public/script.js
+++ b/public/script.js
@@ -6,7 +6,49 @@ const joinBtn = document.getElementById('joinBtn');
 const rollBtn = document.getElementById('rollBtn');
 const logDiv = document.getElementById('log');
 const boardDiv = document.getElementById('board');
-let boardSize = 20;
+let boardSize = 40;
+const spaces = [
+    {name: 'Go', color: ''},
+    {name: 'Mediterranean Ave', color: '#8B4513'},
+    {name: 'Community Chest', icon: '🎁'},
+    {name: 'Baltic Ave', color: '#8B4513'},
+    {name: 'Income Tax', icon: '💰'},
+    {name: 'Reading RR', color: '#000'},
+    {name: 'Oriental Ave', color: '#ADD8E6'},
+    {name: 'Chance', icon: '❓'},
+    {name: 'Vermont Ave', color: '#ADD8E6'},
+    {name: 'Connecticut Ave', color: '#ADD8E6'},
+    {name: 'Jail', icon: '🚓'},
+    {name: 'St. Charles Pl', color: '#FF00FF'},
+    {name: 'Electric Co', icon: '💡'},
+    {name: 'States Ave', color: '#FF00FF'},
+    {name: 'Virginia Ave', color: '#FF00FF'},
+    {name: 'Pennsylvania RR', color: '#000'},
+    {name: 'St. James Pl', color: '#FFA500'},
+    {name: 'Community Chest', icon: '🎁'},
+    {name: 'Tennessee Ave', color: '#FFA500'},
+    {name: 'New York Ave', color: '#FFA500'},
+    {name: 'Free Parking', icon: '🅿️'},
+    {name: 'Kentucky Ave', color: '#FF0000'},
+    {name: 'Chance', icon: '❓'},
+    {name: 'Indiana Ave', color: '#FF0000'},
+    {name: 'Illinois Ave', color: '#FF0000'},
+    {name: 'B&O RR', color: '#000'},
+    {name: 'Atlantic Ave', color: '#FFFF00'},
+    {name: 'Ventnor Ave', color: '#FFFF00'},
+    {name: 'Water Works', icon: '🚰'},
+    {name: 'Marvin Gardens', color: '#FFFF00'},
+    {name: 'Go To Jail', icon: '🚔'},
+    {name: 'Pacific Ave', color: '#008000'},
+    {name: 'North Carolina Ave', color: '#008000'},
+    {name: 'Community Chest', icon: '🎁'},
+    {name: 'Pennsylvania Ave', color: '#008000'},
+    {name: 'Short Line', color: '#000'},
+    {name: 'Chance', icon: '❓'},
+    {name: 'Park Place', color: '#0000FF'},
+    {name: 'Luxury Tax', icon: '💎'},
+    {name: 'Boardwalk', color: '#0000FF'}
+];
 let boardCoords = [];
 let players = [];
 let playerId = null;
@@ -53,19 +95,25 @@ socket.on('state', state => {
 });
 
 function buildBoard() {
-    const N = 6; // 6x6 grid => 20 spaces
+    const N = 11; // 11x11 grid => 40 spaces
     boardCoords = [];
-    boardDiv.innerHTML = '';
+    boardDiv.querySelectorAll('.space').forEach(s => s.remove());
     for (let c = N - 1; c >= 0; c--) boardCoords.push({ row: N - 1, col: c });
     for (let r = N - 2; r >= 0; r--) boardCoords.push({ row: r, col: 0 });
     for (let c = 1; c <= N - 1; c++) boardCoords.push({ row: 0, col: c });
     for (let r = 1; r <= N - 2; r++) boardCoords.push({ row: r, col: N - 1 });
     boardCoords.forEach((pos, idx) => {
+        const spaceData = spaces[idx] || { name: '', color: '' };
         const div = document.createElement('div');
         div.className = 'space';
+        if (spaceData.color) {
+            div.classList.add('property');
+            div.style.borderTopColor = spaceData.color;
+        }
         div.dataset.index = idx;
         div.style.gridRowStart = pos.row + 1;
         div.style.gridColumnStart = pos.col + 1;
+        div.innerHTML = `<div>${spaceData.icon || ''}</div><div>${spaceData.name}</div><div class="tokens"></div>`;
         boardDiv.appendChild(div);
     });
 }
@@ -78,7 +126,8 @@ function renderTokens() {
             const token = document.createElement('div');
             token.className = `token p${idx}`;
             token.title = p.name;
-            space.appendChild(token);
+            const container = space.querySelector('.tokens');
+            container.appendChild(token);
         }
     });
 }

--- a/server.js
+++ b/server.js
@@ -8,7 +8,7 @@ const io = new Server(server);
 
 app.use(express.static('public'));
 
-const BOARD_SIZE = 20; // spaces around the board
+const BOARD_SIZE = 40; // spaces around the board
 let players = [];
 let currentTurn = 0;
 


### PR DESCRIPTION
## Summary
- redesign layout with board centered and controls/stats sidebars
- style board spaces for Monopoly look
- add property metadata and color-coded spaces
- enlarge game board to 40 spaces

## Testing
- `npm install`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6845d05c81248322a50bf8d9979008e0