### PR TITLE
Add Monopoly style rules

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19,6 +19,10 @@
         .p2 { background: green; }
         .p3 { background: yellow; }
         .property { border-top: 10px solid; }
+        .owned-0 { background: rgba(255,0,0,0.2); }
+        .owned-1 { background: rgba(0,0,255,0.2); }
+        .owned-2 { background: rgba(0,128,0,0.2); }
+        .owned-3 { background: rgba(255,255,0,0.2); }
     </style>
 </head>
 <body>
@@ -31,6 +35,7 @@
         <div id="layout">
             <div id="controls">
                 <button id="rollBtn">Roll Dice</button>
+                <button id="buyBtn" disabled>Buy</button>
             </div>
             <div id="boardWrapper">
                 <div id="board">

--- a/public/script.js
+++ b/public/script.js
@@ -4,53 +4,56 @@ const gameDiv = document.getElementById('game');
 const nameInput = document.getElementById('name');
 const joinBtn = document.getElementById('joinBtn');
 const rollBtn = document.getElementById('rollBtn');
+const buyBtn = document.getElementById('buyBtn');
 const logDiv = document.getElementById('log');
 const boardDiv = document.getElementById('board');
+const statsDiv = document.getElementById('stats');
 let boardSize = 40;
 const spaces = [
-    {name: 'Go', color: ''},
-    {name: 'Mediterranean Ave', color: '#8B4513'},
+    {name: 'Go', color: '', price: 0},
+    {name: 'Mediterranean Ave', color: '#8B4513', price: 60},
     {name: 'Community Chest', icon: '🎁'},
-    {name: 'Baltic Ave', color: '#8B4513'},
+    {name: 'Baltic Ave', color: '#8B4513', price: 60},
     {name: 'Income Tax', icon: '💰'},
-    {name: 'Reading RR', color: '#000'},
-    {name: 'Oriental Ave', color: '#ADD8E6'},
+    {name: 'Reading RR', color: '#000', price: 200},
+    {name: 'Oriental Ave', color: '#ADD8E6', price: 100},
     {name: 'Chance', icon: '❓'},
-    {name: 'Vermont Ave', color: '#ADD8E6'},
-    {name: 'Connecticut Ave', color: '#ADD8E6'},
+    {name: 'Vermont Ave', color: '#ADD8E6', price: 100},
+    {name: 'Connecticut Ave', color: '#ADD8E6', price: 120},
     {name: 'Jail', icon: '🚓'},
-    {name: 'St. Charles Pl', color: '#FF00FF'},
-    {name: 'Electric Co', icon: '💡'},
-    {name: 'States Ave', color: '#FF00FF'},
-    {name: 'Virginia Ave', color: '#FF00FF'},
-    {name: 'Pennsylvania RR', color: '#000'},
-    {name: 'St. James Pl', color: '#FFA500'},
+    {name: 'St. Charles Pl', color: '#FF00FF', price: 140},
+    {name: 'Electric Co', icon: '💡', price: 150},
+    {name: 'States Ave', color: '#FF00FF', price: 140},
+    {name: 'Virginia Ave', color: '#FF00FF', price: 160},
+    {name: 'Pennsylvania RR', color: '#000', price: 200},
+    {name: 'St. James Pl', color: '#FFA500', price: 180},
     {name: 'Community Chest', icon: '🎁'},
-    {name: 'Tennessee Ave', color: '#FFA500'},
-    {name: 'New York Ave', color: '#FFA500'},
+    {name: 'Tennessee Ave', color: '#FFA500', price: 180},
+    {name: 'New York Ave', color: '#FFA500', price: 200},
     {name: 'Free Parking', icon: '🅿️'},
-    {name: 'Kentucky Ave', color: '#FF0000'},
+    {name: 'Kentucky Ave', color: '#FF0000', price: 220},
     {name: 'Chance', icon: '❓'},
-    {name: 'Indiana Ave', color: '#FF0000'},
-    {name: 'Illinois Ave', color: '#FF0000'},
-    {name: 'B&O RR', color: '#000'},
-    {name: 'Atlantic Ave', color: '#FFFF00'},
-    {name: 'Ventnor Ave', color: '#FFFF00'},
-    {name: 'Water Works', icon: '🚰'},
-    {name: 'Marvin Gardens', color: '#FFFF00'},
+    {name: 'Indiana Ave', color: '#FF0000', price: 220},
+    {name: 'Illinois Ave', color: '#FF0000', price: 240},
+    {name: 'B&O RR', color: '#000', price: 200},
+    {name: 'Atlantic Ave', color: '#FFFF00', price: 260},
+    {name: 'Ventnor Ave', color: '#FFFF00', price: 260},
+    {name: 'Water Works', icon: '🚰', price: 150},
+    {name: 'Marvin Gardens', color: '#FFFF00', price: 280},
     {name: 'Go To Jail', icon: '🚔'},
-    {name: 'Pacific Ave', color: '#008000'},
-    {name: 'North Carolina Ave', color: '#008000'},
+    {name: 'Pacific Ave', color: '#008000', price: 300},
+    {name: 'North Carolina Ave', color: '#008000', price: 300},
     {name: 'Community Chest', icon: '🎁'},
-    {name: 'Pennsylvania Ave', color: '#008000'},
-    {name: 'Short Line', color: '#000'},
+    {name: 'Pennsylvania Ave', color: '#008000', price: 320},
+    {name: 'Short Line', color: '#000', price: 200},
     {name: 'Chance', icon: '❓'},
-    {name: 'Park Place', color: '#0000FF'},
+    {name: 'Park Place', color: '#0000FF', price: 350},
     {name: 'Luxury Tax', icon: '💎'},
-    {name: 'Boardwalk', color: '#0000FF'}
+    {name: 'Boardwalk', color: '#0000FF', price: 400}
 ];
 let boardCoords = [];
 let players = [];
+let propertyOwners = [];
 let playerId = null;
 
 joinBtn.onclick = () => {
@@ -63,11 +66,20 @@ rollBtn.onclick = () => {
     socket.emit('rollDice');
 };
 
+buyBtn.onclick = () => {
+    const me = players.find(p => p.id === playerId);
+    if (!me) return;
+    socket.emit('buyProperty', me.position);
+};
+
 socket.on('joined', (id) => {
     playerId = id;
     joinDiv.style.display = 'none';
     gameDiv.style.display = 'block';
-    if (boardCoords.length === 0) buildBoard();
+    if (boardCoords.length === 0) {
+        buildBoard();
+        renderOwnership();
+    }
 });
 
 socket.on('message', msg => {
@@ -79,19 +91,25 @@ socket.on('message', msg => {
 
 socket.on('yourTurn', () => {
     rollBtn.disabled = false;
+    updateBuyButton();
 });
 
 socket.on('notYourTurn', () => {
     rollBtn.disabled = true;
+    buyBtn.disabled = true;
 });
 
 socket.on('state', state => {
     boardSize = state.boardSize;
     players = state.players;
+    propertyOwners = state.propertyOwners || [];
     if (boardCoords.length === 0) {
         buildBoard();
     }
     renderTokens();
+    renderOwnership();
+    renderStats();
+    updateBuyButton();
 });
 
 function buildBoard() {
@@ -113,7 +131,8 @@ function buildBoard() {
         div.dataset.index = idx;
         div.style.gridRowStart = pos.row + 1;
         div.style.gridColumnStart = pos.col + 1;
-        div.innerHTML = `<div>${spaceData.icon || ''}</div><div>${spaceData.name}</div><div class="tokens"></div>`;
+        const price = spaceData.price ? `<div>$${spaceData.price}</div>` : '';
+        div.innerHTML = `<div>${spaceData.icon || ''}</div><div>${spaceData.name}</div>${price}<div class="tokens"></div>`;
         boardDiv.appendChild(div);
     });
 }
@@ -130,4 +149,44 @@ function renderTokens() {
             container.appendChild(token);
         }
     });
+}
+
+function renderOwnership() {
+    document.querySelectorAll('.space').forEach(div => {
+        div.classList.remove('owned-0', 'owned-1', 'owned-2', 'owned-3');
+    });
+    propertyOwners.forEach((owner, idx) => {
+        if (owner == null) return;
+        const space = boardDiv.querySelector(`.space[data-index="${idx}"]`);
+        if (space) space.classList.add(`owned-${owner}`);
+    });
+}
+
+function renderStats() {
+    statsDiv.innerHTML = '';
+    players.forEach((p, idx) => {
+        const div = document.createElement('div');
+        div.style.border = '1px solid #ccc';
+        div.style.padding = '4px';
+        div.style.marginBottom = '4px';
+        div.innerHTML = `<strong style="color:${getTokenColor(idx)}">${p.name}</strong><br>$${p.money}<br>${p.properties.map(i => spaces[i].name).join(', ')}`;
+        statsDiv.appendChild(div);
+    });
+}
+
+function getTokenColor(idx) {
+    const colors = ['red','blue','green','yellow'];
+    return colors[idx] || 'black';
+}
+
+function updateBuyButton() {
+    const me = players.find(p => p.id === playerId);
+    if (!me) { buyBtn.disabled = true; return; }
+    const pos = me.position;
+    const space = spaces[pos];
+    if (space && space.price && propertyOwners[pos] == null && me.money >= space.price) {
+        buyBtn.disabled = false;
+    } else {
+        buyBtn.disabled = true;
+    }
 }

--- a/server.js
+++ b/server.js
@@ -9,6 +9,91 @@ const io = new Server(server);
 app.use(express.static('public'));
 
 const BOARD_SIZE = 40; // spaces around the board
+const PROPERTY_INFO = [
+  { price: 0 },
+  { price: 60 },
+  { price: 0 },
+  { price: 60 },
+  { price: 0 },
+  { price: 200 },
+  { price: 100 },
+  { price: 0 },
+  { price: 100 },
+  { price: 120 },
+  { price: 0 },
+  { price: 140 },
+  { price: 150 },
+  { price: 140 },
+  { price: 160 },
+  { price: 200 },
+  { price: 180 },
+  { price: 0 },
+  { price: 180 },
+  { price: 200 },
+  { price: 0 },
+  { price: 220 },
+  { price: 0 },
+  { price: 220 },
+  { price: 240 },
+  { price: 200 },
+  { price: 260 },
+  { price: 260 },
+  { price: 150 },
+  { price: 280 },
+  { price: 0 },
+  { price: 300 },
+  { price: 300 },
+  { price: 0 },
+  { price: 320 },
+  { price: 200 },
+  { price: 0 },
+  { price: 350 },
+  { price: 0 },
+  { price: 400 }
+];
+const SPACE_NAMES = [
+  'Go',
+  'Mediterranean Ave',
+  'Community Chest',
+  'Baltic Ave',
+  'Income Tax',
+  'Reading RR',
+  'Oriental Ave',
+  'Chance',
+  'Vermont Ave',
+  'Connecticut Ave',
+  'Jail',
+  'St. Charles Pl',
+  'Electric Co',
+  'States Ave',
+  'Virginia Ave',
+  'Pennsylvania RR',
+  'St. James Pl',
+  'Community Chest',
+  'Tennessee Ave',
+  'New York Ave',
+  'Free Parking',
+  'Kentucky Ave',
+  'Chance',
+  'Indiana Ave',
+  'Illinois Ave',
+  'B&O RR',
+  'Atlantic Ave',
+  'Ventnor Ave',
+  'Water Works',
+  'Marvin Gardens',
+  'Go To Jail',
+  'Pacific Ave',
+  'North Carolina Ave',
+  'Community Chest',
+  'Pennsylvania Ave',
+  'Short Line',
+  'Chance',
+  'Park Place',
+  'Luxury Tax',
+  'Boardwalk'
+];
+let propertyOwners = Array(BOARD_SIZE).fill(null);
 let players = [];
 let currentTurn = 0;
 
@@ -18,11 +103,11 @@ io.on('connection', socket => {
       socket.emit('message', 'Game is full');
       return;
     }
-    const player = { id: socket.id, name, position: 0 };
+    const player = { id: socket.id, name, position: 0, money: 1500, properties: [] };
     players.push(player);
     socket.emit('joined', socket.id);
     io.emit('message', `${name} joined the game.`);
-    io.emit('state', { players, boardSize: BOARD_SIZE });
+    io.emit('state', { players, boardSize: BOARD_SIZE, propertyOwners });
     if (players.length === 1) {
       io.to(players[0].id).emit('yourTurn');
     } else {
@@ -39,9 +124,19 @@ io.on('connection', socket => {
     const roll1 = Math.floor(Math.random() * 6) + 1;
     const roll2 = Math.floor(Math.random() * 6) + 1;
     const total = roll1 + roll2;
+    const oldPos = player.position;
     player.position = (player.position + total) % BOARD_SIZE;
+    if (player.position < oldPos) {
+      player.money += 200;
+      io.emit('message', `${player.name} passed Go and collected $200.`);
+    }
     io.emit('message', `${player.name} rolled ${roll1} and ${roll2} (total ${total})`);
-    io.emit('state', { players, boardSize: BOARD_SIZE });
+    io.emit('state', { players, boardSize: BOARD_SIZE, propertyOwners });
+    if (roll1 === roll2) {
+      io.to(player.id).emit('yourTurn');
+      players.forEach(p => { if (p.id !== player.id) io.to(p.id).emit('notYourTurn'); });
+      return;
+    }
     currentTurn = (currentTurn + 1) % players.length;
     io.to(players[currentTurn].id).emit('yourTurn');
     players.forEach(p => {
@@ -51,16 +146,33 @@ io.on('connection', socket => {
     });
   });
 
+  socket.on('buyProperty', index => {
+    const player = players.find(p => p.id === socket.id);
+    if (!player) return;
+    const info = PROPERTY_INFO[index];
+    if (!info || !info.price || propertyOwners[index]) return;
+    if (player.money < info.price) return;
+    player.money -= info.price;
+    player.properties.push(index);
+    propertyOwners[index] = players.indexOf(player);
+    io.emit('message', `${player.name} bought ${SPACE_NAMES[index]} for $${info.price}.`);
+    io.emit('state', { players, boardSize: BOARD_SIZE, propertyOwners });
+  });
+
   socket.on('disconnect', () => {
     const idx = players.findIndex(p => p.id === socket.id);
     if (idx === -1) return;
 
     const [leaving] = players.splice(idx, 1);
+    propertyOwners = propertyOwners.map(o => (o === idx ? null : o));
+    // adjust indices for owners after the leaving player
+    propertyOwners = propertyOwners.map(o => (o !== null && o > idx ? o - 1 : o));
     io.emit('message', `${leaving.name} left the game.`);
-    io.emit('state', { players, boardSize: BOARD_SIZE });
+    io.emit('state', { players, boardSize: BOARD_SIZE, propertyOwners });
 
     if (players.length === 0) {
       currentTurn = 0;
+      propertyOwners = Array(BOARD_SIZE).fill(null);
       return;
     }
 


### PR DESCRIPTION
## Summary
- implement player money and property ownership
- add property prices and buy button
- show board ownership with pastel backgrounds
- pass GO gives $200 and doubles roll again
- display player stats and property list

## Testing
- `npm test` *(fails: Missing script)*
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6845d37fdf9c8322b1685a156f364154