### PR TITLE
Add Monopoly game mechanics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -36,6 +36,8 @@
             <div id="controls">
                 <button id="rollBtn">Roll Dice</button>
                 <button id="buyBtn" disabled>Buy</button>
+                <button id="payJailBtn" disabled>Pay Bail</button>
+                <button id="useCardBtn" disabled>Use Card</button>
                 <button id="endTurnBtn" disabled>End Turn</button>
             </div>
             <div id="boardWrapper">


### PR DESCRIPTION
## Summary
- add rent information to property data
- create chance and community chest decks with effects
- implement jail handling and "Get Out of Jail Free" inventory
- charge rent when landing on owned properties
- color-coded logging and expanded UI controls

## Testing
- `node --check server.js`
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6845e1a1a7a88322a2cbc291c58263ba