### PR TITLE
Add mortgage and building mechanics

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -13,6 +13,7 @@
         #log { grid-column: 2 / 11; grid-row: 2 / 11; border: 1px solid #ccc; overflow-y: scroll; background: #fff; padding: 5px; }
         .space { border: 1px solid #999; position: relative; font-size: 10px; display: flex; flex-direction: column; align-items: center; justify-content: flex-start; }
         .space .tokens { display: flex; gap: 2px; flex-wrap: wrap; margin-top: auto; padding-bottom: 2px; }
+        .space .buildings { display: flex; gap: 2px; }
         .token { width: 14px; height: 14px; border-radius: 50%; }
         .p0 { background: red; }
         .p1 { background: blue; }
@@ -23,6 +24,7 @@
         .owned-1 { background: rgba(0,0,255,0.2); }
         .owned-2 { background: rgba(0,128,0,0.2); }
         .owned-3 { background: rgba(255,255,0,0.2); }
+        .mortgaged { filter: grayscale(100%) brightness(70%); }
     </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- enable mortgaging and building houses/hotels
- track mortgaged properties and improvements
- eliminate players who finish a turn in debt
- show property actions and building icons in UI

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6845e70b6cfc832298eeff85314b643c