### PR TITLE
Improve property interactions and add keyboard shortcut

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -40,6 +40,7 @@
                     <div id="log"></div>
                     <div id="tokenLayer" style="position:absolute;top:0;left:0;right:0;bottom:0;pointer-events:none;"></div>
                 </div>
+                <div id="propertyMenu" style="display:none;"></div>
             </div>
             <div id="stats"></div>
         </div>

--- a/public/style.css
+++ b/public/style.css
@@ -130,3 +130,26 @@ body {
     pointer-events: none;
     z-index: 10;
 }
+
+#propertyMenu {
+    position: absolute;
+    background: #fff;
+    border: 1px solid #ccc;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.3);
+    font-size: 12px;
+    z-index: 20;
+}
+
+#propertyMenu button {
+    display: block;
+    width: 100%;
+    padding: 4px 8px;
+    background: none;
+    border: none;
+    text-align: left;
+    cursor: pointer;
+}
+
+#propertyMenu button:hover {
+    background: #eee;
+}


### PR DESCRIPTION
## Summary
- add context menu element in board layout
- style property context menu
- implement right-click menu for properties
- enable Enter key to roll dice or end turn

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848c66a2504832294147d03393da3d5