### PR TITLE
Add socket.io integration tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "jest": "^29.7.0",
+        "socket.io-client": "^4.7.4",
         "supertest": "^7.1.1"
       }
     },
@@ -1928,6 +1929,45 @@
       "engines": {
         "node": ">=10.2.0"
       }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.3",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.3.tgz",
+      "integrity": "sha512-T0iLjnyNWahNyv/lcjS2y4oE358tVS/SYQNxYXGAJ9/GLgH4VCvOQ/mhTjqU88mLZCQgiG8RIegFHYCdVC+j5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/engine.io-parser": {
       "version": "5.2.3",
@@ -4376,6 +4416,47 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.1.tgz",
+      "integrity": "sha512-hJVXfu3E28NmzGk8o1sHhN3om52tRvwYeidbj7xKy2eIIse5IoKX3USlS6Tqt3BHAtflLIkCQBkzVrEEfWUyYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-client/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-client/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/socket.io-parser": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
@@ -4902,6 +4983,15 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "jest": "^29.7.0",
-    "supertest": "^7.1.1"
+    "supertest": "^7.1.1",
+    "socket.io-client": "^4.7.4"
   }
 }

--- a/server.js
+++ b/server.js
@@ -45,3 +45,4 @@ if (require.main === module) {
 }
 
 module.exports = app;
+module.exports.httpServer = server;

--- a/tests/socket.test.js
+++ b/tests/socket.test.js
@@ -1,0 +1,91 @@
+const request = require('supertest');
+const { io: Client } = require('socket.io-client');
+const app = require('../server');
+let server;
+let port;
+let url;
+
+beforeAll(done => {
+  server = app.httpServer;
+  server.listen(() => {
+    port = server.address().port;
+    url = `http://localhost:${port}`;
+    done();
+  });
+});
+
+afterAll(done => {
+  server.close(done);
+});
+
+test('create lobby via websocket', done => {
+  const client = new Client(url, { transports: ['websocket'], forceNew: true });
+  client.emit('createLobby', { code: 'l1', name: 'Lobby 1' });
+  client.on('lobbyCreated', code => {
+    expect(code).toBe('l1');
+    client.close();
+    done();
+  });
+});
+
+test('join existing lobby via websocket', done => {
+  const host = new Client(url, { transports: ['websocket'], forceNew: true });
+  host.emit('createLobby', { code: 'l2' });
+  host.on('lobbyCreated', () => {
+    const guest = new Client(url, { transports: ['websocket'], forceNew: true });
+    guest.emit('joinLobby', 'l2');
+    guest.on('lobbyJoined', code => {
+      expect(code).toBe('l2');
+      host.close();
+      guest.close();
+      done();
+    });
+  });
+});
+
+test('rolling dice updates player position', done => {
+  const root = new Client(url, { transports: ['websocket'], forceNew: true });
+  root.emit('createLobby', { code: 'game1' });
+  root.on('lobbyCreated', () => {
+    const game = new Client(`${url}/game-game1`, { transports: ['websocket'], forceNew: true });
+    let stateCount = 0;
+    game.on('state', state => {
+      stateCount++;
+      if (stateCount === 1) {
+        // initial state after joining
+        game.emit('rollDice');
+      } else if (stateCount === 2) {
+        expect(state.players[0].position).toBeGreaterThan(0);
+        game.close();
+        root.close();
+        done();
+      }
+    });
+    game.on('yourTurn', () => {
+      // nothing, wait for state listener to trigger rollDice
+    });
+    game.emit('joinGame', 'Alice');
+  });
+});
+
+test('buying property updates money and ownership', done => {
+  const root = new Client(url, { transports: ['websocket'], forceNew: true });
+  root.emit('createLobby', { code: 'game2' });
+  root.on('lobbyCreated', () => {
+    const game = new Client(`${url}/game-game2`, { transports: ['websocket'], forceNew: true });
+    let stateCount = 0;
+    game.on('state', state => {
+      stateCount++;
+      if (stateCount === 1) {
+        game.emit('buyProperty', 1);
+      } else if (stateCount === 2) {
+        expect(state.players[0].money).toBe(1440);
+        expect(state.propertyOwners[1]).toBe(0);
+        game.close();
+        root.close();
+        done();
+      }
+    });
+    game.emit('joinGame', 'Bob');
+  });
+});


### PR DESCRIPTION
## Summary
- export http server from `server.js`
- install `socket.io-client`
- add integration tests for lobby creation, joining, dice rolling and property buying

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a146b6b1483228edd3cfa1e4e2e8a