### PR TITLE
Implement lobby cleanup when no players remain

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,4 +1,10 @@
 module.exports = function(io, events) {
+  function maybeCleanup() {
+    if (players.length === 0 && io.sockets.size === 0 && events) {
+      const code = io.name.replace(/^\/game-/, '');
+      events.emit('cleanup', code);
+    }
+  }
 const BOARD_SIZE = 40; // spaces around the board
 const PROPERTY_INFO = [
   { price: 0 },
@@ -122,8 +128,7 @@ function eliminatePlayer(idx) {
     propertyMortgaged = Array(BOARD_SIZE).fill(false);
     propertyHouses = Array(BOARD_SIZE).fill(0);
     clearTimeout(turnTimer);
-    const code = io.name.replace(/^\/game-/, '');
-    if (events) events.emit('cleanup', code);
+    maybeCleanup();
     return;
   }
 
@@ -839,8 +844,7 @@ io.on('connection', socket => {
       propertyMortgaged = Array(BOARD_SIZE).fill(false);
       propertyHouses = Array(BOARD_SIZE).fill(0);
       clearTimeout(turnTimer);
-      const code = io.name.replace(/^\/game-/, '');
-      if (events) events.emit('cleanup', code);
+      maybeCleanup();
       return;
     }
 
@@ -859,6 +863,7 @@ io.on('connection', socket => {
       });
       startTurnTimer();
     }
+    maybeCleanup();
   });
 });
 };

--- a/game.js
+++ b/game.js
@@ -1,4 +1,4 @@
-module.exports = function(io) {
+module.exports = function(io, events) {
 const BOARD_SIZE = 40; // spaces around the board
 const PROPERTY_INFO = [
   { price: 0 },
@@ -122,6 +122,8 @@ function eliminatePlayer(idx) {
     propertyMortgaged = Array(BOARD_SIZE).fill(false);
     propertyHouses = Array(BOARD_SIZE).fill(0);
     clearTimeout(turnTimer);
+    const code = io.name.replace(/^\/game-/, '');
+    if (events) events.emit('cleanup', code);
     return;
   }
 
@@ -837,6 +839,8 @@ io.on('connection', socket => {
       propertyMortgaged = Array(BOARD_SIZE).fill(false);
       propertyHouses = Array(BOARD_SIZE).fill(0);
       clearTimeout(turnTimer);
+      const code = io.name.replace(/^\/game-/, '');
+      if (events) events.emit('cleanup', code);
       return;
     }
 

--- a/tests/cleanup.test.js
+++ b/tests/cleanup.test.js
@@ -1,0 +1,14 @@
+const { io, createLobby, lobbies, gameEvents } = require('../server');
+
+describe('cleanup event', () => {
+  it('removes lobby and namespace', () => {
+    createLobby('XYZ', 'test');
+    expect(lobbies['XYZ']).toBeDefined();
+    expect(io._nsps.has('/game-XYZ')).toBe(true);
+
+    gameEvents.emit('cleanup', 'XYZ');
+
+    expect(lobbies['XYZ']).toBeUndefined();
+    expect(io._nsps.has('/game-XYZ')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- use an event emitter to signal when a game namespace becomes empty
- handle cleanup in `server.js` by removing the lobby and deleting the namespace
- export the new emitter for tests
- test that cleanup removes lobbies and namespaces

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a145945e4832295a0107929e4eef4