### PR TITLE
Add turn indicator and token highlight

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,6 +29,7 @@
                 <button id="payJailBtn" disabled>Pay Bail</button>
                 <button id="useCardBtn" disabled>Use Card</button>
                 <button id="endTurnBtn" disabled>End Turn</button>
+                <div id="turnIndicator"></div>
                 <div id="chat">
                     <div id="chatMessages"></div>
                     <input id="chatInput" placeholder="Say something" />

--- a/public/js/dom.js
+++ b/public/js/dom.js
@@ -14,6 +14,7 @@ export const tradeBtn = document.getElementById('tradeBtn');
 export const endTurnBtn = document.getElementById('endTurnBtn');
 export const payJailBtn = document.getElementById('payJailBtn');
 export const useCardBtn = document.getElementById('useCardBtn');
+export const turnIndicator = document.getElementById('turnIndicator');
 export const logDiv = document.getElementById('log');
 export const boardDiv = document.getElementById('board');
 export const boardWrapper = document.getElementById('boardWrapper');

--- a/public/js/index.js
+++ b/public/js/index.js
@@ -1,7 +1,7 @@
 import * as DOM from './dom.js';
 import { setSocket } from './dom.js';
 import { registerGameEvents } from './socketHandlers.js';
-const { rootSocket, joinDiv, gameDiv, nameInput, createBtn, createCodeInput, lobbyNameInput, joinCodeInput, joinBtn, rollBtn, buyBtn, tradeBtn, endTurnBtn, payJailBtn, useCardBtn, logDiv, boardDiv, boardWrapper, tokenLayer, statsDiv, tradeModal, tradeStartDiv, tradeWindowDiv, tradeTargetSelect, tradeInitBtn, tradeTitle, yourPropsDiv, theirPropsDiv, yourMoneyInput, theirMoneyInput, yourCardsInput, theirCardsInput, tradeAcceptBtn, tradeCancelBtn, tradeStatusDiv, auctionModal, auctionTitle, auctionBidSpan, auctionBidderSpan, auctionCountdown, auctionBidBtn, auctionCloseBtn, chatMessages, chatInput, chatSend, propertyMenu } = DOM;
+const { rootSocket, joinDiv, gameDiv, nameInput, createBtn, createCodeInput, lobbyNameInput, joinCodeInput, joinBtn, rollBtn, buyBtn, tradeBtn, endTurnBtn, payJailBtn, useCardBtn, logDiv, boardDiv, boardWrapper, tokenLayer, statsDiv, tradeModal, tradeStartDiv, tradeWindowDiv, tradeTargetSelect, tradeInitBtn, tradeTitle, yourPropsDiv, theirPropsDiv, yourMoneyInput, theirMoneyInput, yourCardsInput, theirCardsInput, tradeAcceptBtn, tradeCancelBtn, tradeStatusDiv, auctionModal, auctionTitle, auctionBidSpan, auctionBidderSpan, auctionCountdown, auctionBidBtn, auctionCloseBtn, chatMessages, chatInput, chatSend, propertyMenu, turnIndicator } = DOM;
 let { socket } = DOM;
 let menuPropertyIndex = null;
 let boardSize = 40;
@@ -21,12 +21,26 @@ let currentTrade = null;
 let lastPositions = {};
 let tokenElems = {};
 
+function highlightMyToken() {
+    const idx = players.findIndex(p => p.id === playerId);
+    const token = tokenElems[idx];
+    if (token) token.classList.add('active-token');
+}
+
+function unhighlightMyToken() {
+    const idx = players.findIndex(p => p.id === playerId);
+    const token = tokenElems[idx];
+    if (token) token.classList.remove('active-token');
+}
+
 function startGame(code, name) {
     boardPromise.then(() => {
         const s = io(`/game-${code}`);
         setSocket(s);
         socket = s;
         registerGameEvents(socket);
+        socket.on('yourTurn', highlightMyToken);
+        socket.on('notYourTurn', unhighlightMyToken);
         socket.emit('joinGame', name);
     });
 }

--- a/public/js/socketHandlers.js
+++ b/public/js/socketHandlers.js
@@ -1,3 +1,5 @@
+import { turnIndicator } from './dom.js';
+
 export function registerGameEvents(s) {
     s.on('joined', id => {
         playerId = id;
@@ -34,6 +36,10 @@ export function registerGameEvents(s) {
         tradeBtn.disabled = false;
         updateJailButtons();
         updateBuyButton();
+        if (turnIndicator) {
+            turnIndicator.textContent = 'Your Turn!';
+            turnIndicator.classList.add('active');
+        }
     });
 
     s.on('notYourTurn', () => {
@@ -43,6 +49,10 @@ export function registerGameEvents(s) {
         useCardBtn.disabled = true;
         endTurnBtn.disabled = true;
         tradeBtn.disabled = true;
+        if (turnIndicator) {
+            turnIndicator.textContent = 'Waiting...';
+            turnIndicator.classList.remove('active');
+        }
     });
 
     s.on('state', state => {

--- a/public/style.css
+++ b/public/style.css
@@ -153,3 +153,20 @@ body {
 #propertyMenu button:hover {
     background: #eee;
 }
+
+#turnIndicator {
+    margin-top: 10px;
+    font-weight: bold;
+    text-align: center;
+}
+
+#turnIndicator.active {
+    color: #fff;
+    background: #4caf50;
+    border-radius: 4px;
+    padding: 4px;
+}
+
+.active-token {
+    outline: 3px solid gold;
+}


### PR DESCRIPTION
## Summary
- show a turn indicator element in the UI
- style the indicator and active token
- update socket handlers to toggle the indicator text
- highlight the current player's token when it's your turn

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a1be6c0148322a0140af58e92da05