### PR TITLE
Fix lobby creation responsiveness

### DIFF
--- a/public/js/index.js
+++ b/public/js/index.js
@@ -50,18 +50,36 @@ createBtn.onclick = () => {
     const code = createCodeInput.value.trim();
     const lobbyName = lobbyNameInput.value.trim();
     if (!name || !code) return;
-    rootSocket.emit('createLobby', { code, name: lobbyName });
-    rootSocket.once('lobbyCreated', c => startGame(c, name));
-    rootSocket.once('lobbyError', msg => alert(msg));
+    if (!rootSocket.connected) {
+        alert('Unable to reach server');
+        return;
+    }
+    rootSocket.timeout(5000).emit('createLobby', { code, name: lobbyName }, (err, res) => {
+        if (err) { alert('Server timeout'); return; }
+        if (res && res.error) {
+            alert(res.error);
+        } else {
+            startGame(code, name);
+        }
+    });
 };
 
 joinBtn.onclick = () => {
     const name = nameInput.value.trim();
     const code = joinCodeInput.value.trim();
     if (!name || !code) return;
-    rootSocket.emit('joinLobby', code);
-    rootSocket.once('lobbyJoined', c => startGame(c, name));
-    rootSocket.once('lobbyError', msg => alert(msg));
+    if (!rootSocket.connected) {
+        alert('Unable to reach server');
+        return;
+    }
+    rootSocket.timeout(5000).emit('joinLobby', code, (err, res) => {
+        if (err) { alert('Server timeout'); return; }
+        if (res && res.error) {
+            alert(res.error);
+        } else {
+            startGame(code, name);
+        }
+    });
 };
 
 rollBtn.onclick = () => {

--- a/server.js
+++ b/server.js
@@ -19,23 +19,30 @@ function createLobby(code, name) {
 }
 
 io.on('connection', socket => {
-  socket.on('createLobby', data => {
+  socket.on('createLobby', (data, cb) => {
     const { code, name } = data || {};
-    if (!code) return;
+    if (!code) {
+      if (cb) cb({ error: 'Invalid code' });
+      return;
+    }
     if (lobbies[code]) {
+      if (cb) cb({ error: 'Code already exists' });
       socket.emit('lobbyError', 'Code already exists');
       return;
     }
     createLobby(code, name || '');
     socket.emit('lobbyCreated', code);
+    if (cb) cb({ success: true });
   });
 
-  socket.on('joinLobby', code => {
+  socket.on('joinLobby', (code, cb) => {
     if (!lobbies[code]) {
+      if (cb) cb({ error: 'Lobby not found' });
       socket.emit('lobbyError', 'Lobby not found');
       return;
     }
     socket.emit('lobbyJoined', code);
+    if (cb) cb({ success: true });
   });
 });
 


### PR DESCRIPTION
## Summary
- support ack callbacks for `createLobby` and `joinLobby`
- handle connection errors on the client when creating or joining lobbies

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684a1e52edb883229d6a4494d2929412