### PR TITLE
Speed up closing of auction modal

### DIFF
--- a/public/js/socketHandlers.js
+++ b/public/js/socketHandlers.js
@@ -191,7 +191,7 @@ export function registerGameEvents(s) {
         auctionBidBtn.disabled = true;
         auctionCloseBtn.style.display = 'block';
         clearCurrentAuction();
-        setTimeout(() => { auctionModal.style.display = 'none'; }, 2000);
+        setTimeout(() => { auctionModal.style.display = 'none'; }, 500);
     });
 
     // end of registerGameEvents


### PR DESCRIPTION
## Summary
- shorten the auction modal timeout so the window closes faster

## Testing
- `npm test --silent` *(fails: rolling dice updates player position, buying property updates money and ownership)*

------
https://chatgpt.com/codex/tasks/task_e_684b8295fbe4832285048bcfbd243d52