### PR TITLE
Fix chat send button layout

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -618,6 +618,7 @@ body {
     font-weight: bold;
     cursor: pointer;
     transition: all 0.2s ease;
+    width: auto;
     height: 36px;
     min-width: 40px;
     display: flex;


### PR DESCRIPTION
## Summary
- make chat send button width auto so it sits nicely next to the input

## Testing
- `npm test --silent` *(fails: rolling dice updates player position; buying property updates money and ownership)*

------
https://chatgpt.com/codex/tasks/task_e_684b845a1c1c8322a45d9a0a60f4a954