### PR TITLE
Fix chat send button placement

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -587,21 +587,21 @@ body {
     }
 }
 
-.chat-input-group {
-    display: flex;
-    gap: 6px;
-    align-items: center;
+#chat .chat-input-group {
+    position: relative;
     padding: 2px;
+    width: 100%;
 }
 
 #chatInput {
-    flex: 1;
-    padding: 8px 12px;
+    width: 100%;
+    padding: 8px 36px 8px 12px;
     border: 2px solid #e0e0e0;
     border-radius: 20px;
     font-size: 12px;
     outline: none;
     transition: border-color 0.2s ease;
+    box-sizing: border-box;
 }
 
 #chatInput:focus {
@@ -609,6 +609,10 @@ body {
 }
 
 #chatSend {
+    position: absolute;
+    top: 50%;
+    right: 6px;
+    transform: translateY(-50%);
     background: linear-gradient(145deg, var(--monopoly-green), #0a5a0a);
     color: white;
     border: none;
@@ -618,8 +622,8 @@ body {
     font-weight: bold;
     cursor: pointer;
     transition: all 0.2s ease;
-    height: 36px;
-    min-width: 40px;
+    height: 32px;
+    min-width: 32px;
     display: flex;
     align-items: center;
     justify-content: center;


### PR DESCRIPTION
## Summary
- position chat send button inside the chat input field

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b845a1c1c8322a45d9a0a60f4a954